### PR TITLE
Bump angular-gettext-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "gettext"
   ],
   "dependencies": {
-    "angular-gettext-tools": "git+https://github.com/udemy/angular-gettext-tools.git#9fd0728c9cb37298664c09ed38fa41b63e881722"
+    "angular-gettext-tools": "git+https://github.com/udemy/angular-gettext-tools.git#760b101197526d0d25b9d0de76c353008d70f563"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "gettext"
   ],
   "dependencies": {
-    "angular-gettext-tools": "git+https://github.com/udemy/angular-gettext-tools.git#c61824b1d1bd8afc99e1e6e4eae91d7665bfbd1c"
+    "angular-gettext-tools": "git+https://github.com/udemy/angular-gettext-tools.git#9fd0728c9cb37298664c09ed38fa41b63e881722"
   }
 }


### PR DESCRIPTION
Bump angular-gettext-tools.

Includes https://github.com/udemy/angular-gettext-tools/pull/3.

See also https://github.com/udemy/website-django/pull/36056.